### PR TITLE
fix: Prevent infinite loop in getSessionId

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,7 +11,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@react-navigation/native": "^6.0.13",
         "@react-navigation/native-stack": "^6.9.1",
-        "@splunk/otel-react-native": "file:..",
+        "@hyperdx/otel-react-native": "file:..",
         "react": "18.1.0",
         "react-native": "0.70.8",
         "react-native-safe-area-context": "^4.4.1",
@@ -25,7 +25,7 @@
       }
     },
     "..": {
-      "name": "@splunk/otel-react-native",
+      "name": "@hyperdx/otel-react-native",
       "version": "0.1.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2534,7 +2534,7 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "node_modules/@splunk/otel-react-native": {
+    "node_modules/@hyperdx/otel-react-native": {
       "resolved": "..",
       "link": true
     },
@@ -9288,7 +9288,7 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "@splunk/otel-react-native": {
+    "@hyperdx/otel-react-native": {
       "version": "file:..",
       "requires": {
         "@opentelemetry/api": "^1.3.0",

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.1",
-    "@splunk/otel-react-native": "file:..",
+    "@hyperdx/otel-react-native": "file:..",
     "react": "18.1.0",
     "react-native": "0.70.8",
     "react-native-safe-area-context": "^4.4.1",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -25,11 +25,10 @@ import Details from './Details';
 import {
   OtelWrapper,
   startNavigationTracking,
-} from '@splunk/otel-react-native';
-import type { ReactNativeConfiguration } from '@splunk/otel-react-native';
+} from '@hyperdx/otel-react-native';
+import type { ReactNativeConfiguration } from '@hyperdx/otel-react-native';
 
 const RumConfig: ReactNativeConfiguration = {
-  realm: 'us0',
   // beaconEndpoint: 'http://192.168.1.137:53820/zipkindump',
   service: 'ReactNativeExample',
   apiKey: '',

--- a/src/session.ts
+++ b/src/session.ts
@@ -58,7 +58,15 @@ AppState.addEventListener('change', (nextAppState) => {
   currentState = nextAppState;
 });
 
+let isUpdatingSessionId = false;
+
 export function getSessionId() {
+  // In order to prevent infinite loop when newSessionId() logic calls getSessionId(),
+  // don't update session id if it's already being updated.
+  if (isUpdatingSessionId) {
+    return session.id;
+  }
+
   if (hasExpired() || hasTimedOut()) {
     newSessionId();
   }
@@ -110,6 +118,7 @@ function hasExpired() {
 }
 
 function newSessionId() {
+  isUpdatingSessionId = true;
   const previousId = session.id;
   session.startTime = Date.now();
   session.id = idGenerator.generateTraceId();
@@ -123,6 +132,7 @@ function newSessionId() {
     },
   });
   span.end();
+  isUpdatingSessionId = false;
 }
 
 export function _generatenewSessionId() {


### PR DESCRIPTION
**Background:**

When an app is in background and inactive for over 15 minutes (as set in `SESSION_TIMEOUT` in `src/session.ts`), the following loop occurs in `getSessionId()` method:

```ts
export function getSessionId() {
  if (hasExpired() || hasTimedOut()) {
    newSessionId();
  }
  bump();
  return session.id;
}

// first call:
// - hasTimedOut() is true
// - newSessionId() is called
// - newSessionId() starts a tracker span: tracer.startSpan('sessionId.change', ...)
// - tracer pulls data using  getGlobalAttributes:
export function getGlobalAttributes(): Attributes {
  return Object.assign(globalAttributes, {
    'rum.sessionId': getSessionId(),
  });
}
 
// getSessionId() is called again, `hasTimedOut` is still true and it enters the loop calling newSessionId()
```